### PR TITLE
Improve the role to init our pg instances

### DIFF
--- a/roles/postgres_instance_configure/tasks/configure-Debian.yml
+++ b/roles/postgres_instance_configure/tasks/configure-Debian.yml
@@ -1,4 +1,9 @@
 ---
+- name: Check if postgres pgdata is empty
+  stat:
+    path: "{{ item.pgdata_path }}/PG_VERSION"
+  register: check_pgdata_content_initialized
+
 - name: Ensure PostgreSQL database is initialized.
   shell: |
     /usr/bin/pg_createcluster {{item.postgresql_version}} {{ item.name }} \
@@ -6,9 +11,8 @@
     -D {{ item.pgdata_path }} {{ item.initdb_options|default()|join(' ') }}
   become: true
   become_user: "{{ dalibo_postgresql_user }}"
-  #  when: 
-  #  - not pgdata_dir_version.stat.exists
-  #  - ansible_os_family == 'RedHat'
+  when: not check_pgdata_content_initialized.stat.exists
+
 - name: Set custom options
   debug:
     msg: "{{ an_option }}"

--- a/roles/postgres_instance_configure/tasks/configure-RedHat.yml
+++ b/roles/postgres_instance_configure/tasks/configure-RedHat.yml
@@ -18,3 +18,30 @@
   become: true
   become_user: "{{ dalibo_postgresql_user }}"
   when: not check_pgdata_content_initialized.stat.exists
+
+- name: Set port for our newly created instance
+  lineinfile:
+    path: "{{ item.pgdata_path }}/postgresql.auto.conf"
+    state: present
+    regexp: '^port ='
+    line: "port = '{{ item.port }}'"
+
+- name: Copy systemd unit file
+  copy:
+    src: /lib/systemd/system/postgresql-{{item.postgresql_version}}.service
+    dest: /etc/systemd/system/postgresql-{{item.postgresql_version}}-{{item.name}}.service
+    remote_src: yes
+
+- name: Set PGDATA in unit file
+  replace:
+    regexp: 'PGDATA=.*$'
+    replace: 'PGDATA={{item.pgdata_path }}'
+    path: /etc/systemd/system/postgresql-{{item.postgresql_version}}-{{item.name}}.service
+
+- name: Reload unit and enable our new instance
+  systemd:
+    name: postgresql-{{item.postgresql_version}}-{{item.name}}
+    state: started
+    enabled: yes
+    daemon_reload: yes
+

--- a/roles/postgres_instance_configure/tasks/main.yml
+++ b/roles/postgres_instance_configure/tasks/main.yml
@@ -3,4 +3,3 @@
 - name: Include specific task for RHEL and CentOS
   include_tasks: configure-{{ ansible_os_family }}.yml
   loop: "{{ dalibo_postgresql_instances }}"
-  


### PR DESCRIPTION
- Create unit file on RedHat like OS
- Init the instance only if PGDATA doesn't contain a PG_VERSION file
- Set the port based on dalibo_postgresql_instances config